### PR TITLE
Fix visitListItem protocol dispatch

### DIFF
--- a/Sources/MarkdownToAttributedString/AttributedStringVisitor.swift
+++ b/Sources/MarkdownToAttributedString/AttributedStringVisitor.swift
@@ -306,6 +306,13 @@ struct AttributedStringVisitor: MarkupVisitor {
     }
     
 
+    // Satisfies the single-parameter MarkupVisitor protocol requirement so that
+    // protocol dispatch (e.g. markup.accept(&self)) resolves to this type's
+    // implementation rather than the default provided by the protocol extension.
+    mutating func visitListItem(_ listItem: ListItem) {
+        visitListItem(listItem, orderedIndex: nil)
+    }
+
     // orderedIndex is non-nil when part of an ordered list
     mutating func visitListItem(_ listItem: ListItem, orderedIndex: Int? = nil) {
         guard optionsSupportEl(.listItem) else {


### PR DESCRIPTION
## Summary
- `visitListItem(_:orderedIndex:)` has a second defaulted parameter which prevents it from satisfying the `MarkupVisitor` protocol requirement `visitListItem(_:)`. Swift resolves protocol dispatch (`markup.accept(&self)`) to the default extension implementation (which calls `defaultVisit`), so list item prefixes (bullets/numbers) are never inserted and newlines between items are lost.
- Adds a one-parameter overload that matches the protocol signature and delegates to the two-parameter version.

## Repro
```swift
let result = AttributedStringFormatter.format(markdown: "- Item one\n- Item two")
print(result.string) // "Item oneItem two\n" — no bullets, items concatenated
```

## After fix
```swift
print(result.string) // "\t• Item one\n\t• Item two\n"
```

All existing tests pass (they were previously crashing/failing on list-related assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)